### PR TITLE
Add solution file (enables Deployment Center deploy)

### DIFF
--- a/azure-func-dotnet-isolated-test.csproj
+++ b/azure-func-dotnet-isolated-test.csproj
@@ -5,7 +5,6 @@
     <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <RootNamespace>azure_func_dotnet_isolated_test</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.18.0" />

--- a/azure-func-dotnet-isolated-test.csproj
+++ b/azure-func-dotnet-isolated-test.csproj
@@ -5,6 +5,7 @@
     <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <RootNamespace>azure_func_dotnet_isolated_test</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.18.0" />

--- a/test.sln
+++ b/test.sln
@@ -1,0 +1,22 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "azure-func-dotnet-isolated-test", "azure-func-dotnet-isolated-test.csproj", "{2BCF4BAE-4FA4-4AC8-A688-7AE8CF7CADD6}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{2BCF4BAE-4FA4-4AC8-A688-7AE8CF7CADD6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2BCF4BAE-4FA4-4AC8-A688-7AE8CF7CADD6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2BCF4BAE-4FA4-4AC8-A688-7AE8CF7CADD6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2BCF4BAE-4FA4-4AC8-A688-7AE8CF7CADD6}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
If Deployment Center and Kudu currently do not see the solution file, it makes a bad default to a web app which then causes the function to fail loading downstream.

The workaround is to add this solution file.  We have an ICM ticket to look at Deployment center logic in parallel.

Fixes: [https://github.com/Azure/azure-functions-dotnet-worker/issues/1865](https://github.com/Azure/azure-functions-dotnet-worker/issues/1865)

To add solution like this to any project do this:
```bash
dotnet new sln --name MySolution
dotnet sln add path/to/MyProject.csproj
```
